### PR TITLE
feat: use portal for dropdown menu

### DIFF
--- a/demo/lib/demo_web/live/fixtures_live/dropdown_fixture.html.heex
+++ b/demo/lib/demo_web/live/fixtures_live/dropdown_fixture.html.heex
@@ -3,7 +3,7 @@
     <.dropdown_trigger>
       Open Dropdown
     </.dropdown_trigger>
-    <.dropdown_menu>
+    <.dropdown_menu id="dropdown-menu">
       <.dropdown_item>
         Apple
       </.dropdown_item>

--- a/demo/lib/demo_web/live/fixtures_live/dropdown_with_disabled_fixture.html.heex
+++ b/demo/lib/demo_web/live/fixtures_live/dropdown_with_disabled_fixture.html.heex
@@ -3,7 +3,7 @@
     <.dropdown_trigger>
       Open Dropdown
     </.dropdown_trigger>
-    <.dropdown_menu>
+    <.dropdown_menu id="dropdown-with-disabled-menu">
       <.dropdown_item>
         Enabled Item 1
       </.dropdown_item>

--- a/demo/priv/code_examples/dropdown/basic.html.heex
+++ b/demo/priv/code_examples/dropdown/basic.html.heex
@@ -14,7 +14,7 @@
       />
     </svg>
   </.dropdown_trigger>
-  <.dropdown_menu class="w-56 py-1 rounded-md bg-white shadow-xs ring-1 ring-gray-300 focus:outline-none">
+  <.dropdown_menu id="basic-dropdown-menu" class="w-56 py-1 rounded-md bg-white shadow-xs ring-1 ring-gray-300 focus:outline-none">
     <.dropdown_item
       :for={option <- ["Account settings", "Billing", "Documentation"]}
       class="text-gray-700 data-focus:bg-gray-100 data-focus:text-gray-900 block px-4 py-2 text-sm"

--- a/demo/priv/code_examples/dropdown/disabled.html.heex
+++ b/demo/priv/code_examples/dropdown/disabled.html.heex
@@ -14,7 +14,7 @@
       />
     </svg>
   </.dropdown_trigger>
-  <.dropdown_menu class="w-56 py-1 rounded-md bg-white shadow-xs ring-1 ring-gray-300 focus:outline-none">
+  <.dropdown_menu id="disabled-demo-dropdown-menu" class="w-56 py-1 rounded-md bg-white shadow-xs ring-1 ring-gray-300 focus:outline-none">
     <.dropdown_item class="text-gray-700 data-focus:bg-gray-100 data-focus:text-gray-900 block px-4 py-2 text-sm">
       Edit Profile
     </.dropdown_item>

--- a/demo/priv/code_examples/dropdown/positioned.html.heex
+++ b/demo/priv/code_examples/dropdown/positioned.html.heex
@@ -17,6 +17,7 @@
       </svg>
     </.dropdown_trigger>
     <.dropdown_menu
+      id="top-dropdown-menu"
       placement="top-start"
       class="w-48 py-1rounded-md bg-white shadow-xs ring-1 ring-gray-300 focus:outline-none"
       transition_enter={
@@ -50,6 +51,7 @@
       </svg>
     </.dropdown_trigger>
     <.dropdown_menu
+      id="right-dropdown-menu"
       placement="right-start"
       class="w-48 py-1rounded-md bg-white shadow-xs ring-1 ring-gray-300 focus:outline-none"
       transition_enter={
@@ -83,6 +85,7 @@
       </svg>
     </.dropdown_trigger>
     <.dropdown_menu
+      id="bottom-dropdown-menu"
       placement="bottom-end"
       class="w-48 py-1 rounded-md bg-white shadow-xs ring-1 ring-gray-300 focus:outline-none"
       transition_enter={

--- a/demo/priv/code_examples/dropdown/styled.html.heex
+++ b/demo/priv/code_examples/dropdown/styled.html.heex
@@ -15,6 +15,7 @@
     </svg>
   </.dropdown_trigger>
   <.dropdown_menu
+    id="styled-dropdown-menu"
     class="w-56 divide-y divide-gray-100 rounded-md bg-white shadow-xs ring-1 ring-gray-300 focus:outline-none"
     transition_enter={
       {"ease-out duration-100", "transform opacity-0 scale-95", "transform opacity-100 scale-100"}

--- a/lib/prima/dropdown.ex
+++ b/lib/prima/dropdown.ex
@@ -38,6 +38,7 @@ defmodule Prima.Dropdown do
     end
   end
 
+  attr :id, :string, required: true
   attr :transition_enter, :any, default: nil
   attr :transition_leave, :any, default: nil
   attr :class, :string, default: ""
@@ -62,25 +63,27 @@ defmodule Prima.Dropdown do
   # repositioning. Floating UI cannot measure display:none elements.
   def dropdown_menu(assigns) do
     ~H"""
-    <div
-      style="display: none; position: absolute; top: 0; left: 0;"
-      data-prima-ref="menu-wrapper"
-      data-reference={@reference}
-      data-placement={@placement}
-      data-flip={@flip}
-      data-offset={@offset}
-    >
+    <.portal id={"#{@id}-portal"} target="body">
       <div
-        class={@class}
-        style="display: none;"
-        js-show={JS.show(transition: @transition_enter)}
-        js-hide={JS.hide(transition: @transition_leave)}
-        role="menu"
-        phx-click-away={JS.dispatch("prima:close")}
+        style="display: none; position: absolute; top: 0; left: 0;"
+        data-prima-ref="menu-wrapper"
+        data-reference={@reference}
+        data-placement={@placement}
+        data-flip={@flip}
+        data-offset={@offset}
       >
-        {render_slot(@inner_block)}
+        <div
+          class={@class}
+          style="display: none;"
+          js-show={JS.show(transition: @transition_enter)}
+          js-hide={JS.hide(transition: @transition_leave)}
+          role="menu"
+          phx-click-away={JS.dispatch("prima:close")}
+        >
+          {render_slot(@inner_block)}
+        </div>
       </div>
-    </div>
+    </.portal>
     """
   end
 


### PR DESCRIPTION
## Summary

Implements `<.portal>` for the dropdown menu component, matching the pattern used in the modal component.

## Changes

- Wrap `dropdown_menu` component with `<.portal target="body">`
- Add required `id` attribute to `dropdown_menu` component
- Update all demo usages to include id attribute

This ensures dropdown menus are rendered at the body level for proper positioning and z-index handling, just like modals.

Closes #9

Generated with [Claude Code](https://claude.ai/code)