### PR TITLE
feat: add support for custom component rendering in dropdown

### DIFF
--- a/demo/lib/demo_web/live/fixtures_live.ex
+++ b/demo/lib/demo_web/live/fixtures_live.ex
@@ -83,4 +83,15 @@ defmodule DemoWeb.FixturesLive do
     </span>
     """
   end
+
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  defp custom_button(assigns) do
+    ~H"""
+    <button type="button" {@rest}>
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
 end

--- a/demo/lib/demo_web/live/fixtures_live.html.heex
+++ b/demo/lib/demo_web/live/fixtures_live.html.heex
@@ -6,6 +6,10 @@
   <.dropdown_with_disabled_fixture />
 </div>
 
+<div :if={@live_action == :dropdown_custom_components}>
+  <.dropdown_custom_components_fixture />
+</div>
+
 <div :if={@live_action == :simple_modal}>
   <.simple_modal_fixture />
 </div>

--- a/demo/lib/demo_web/live/fixtures_live/dropdown_custom_components_fixture.html.heex
+++ b/demo/lib/demo_web/live/fixtures_live/dropdown_custom_components_fixture.html.heex
@@ -1,0 +1,18 @@
+<div>
+  <.dropdown id="dropdown-custom">
+    <.dropdown_trigger as={&custom_button/1} data-custom-attr="test-value">
+      Open Dropdown
+    </.dropdown_trigger>
+    <.dropdown_menu>
+      <.dropdown_item>
+        Regular Item
+      </.dropdown_item>
+      <.dropdown_item as={&link/1} navigate={~p"/"}>
+        Link Item
+      </.dropdown_item>
+      <.dropdown_item disabled={true} as={&link/1} href="#disabled">
+        Disabled Link
+      </.dropdown_item>
+    </.dropdown_menu>
+  </.dropdown>
+</div>

--- a/demo/lib/demo_web/router.ex
+++ b/demo/lib/demo_web/router.ex
@@ -23,6 +23,7 @@ defmodule DemoWeb.Router do
     if Mix.env() in [:dev, :test] do
       live "/fixtures/dropdown", FixturesLive, :dropdown
       live "/fixtures/dropdown-with-disabled", FixturesLive, :dropdown_with_disabled
+      live "/fixtures/dropdown-custom-components", FixturesLive, :dropdown_custom_components
       live "/fixtures/simple-modal", FixturesLive, :simple_modal
       live "/fixtures/async-modal", FixturesLive, :async_modal
       live "/fixtures/modal-title-custom-tag", FixturesLive, :modal_title_custom_tag

--- a/demo/test/wallaby/demo_web/dropdown_custom_components_test.exs
+++ b/demo/test/wallaby/demo_web/dropdown_custom_components_test.exs
@@ -1,0 +1,64 @@
+defmodule DemoWeb.DropdownCustomComponentsTest do
+  use Prima.WallabyCase, async: true
+
+  @dropdown_container Query.css("#dropdown-custom")
+  @dropdown_trigger Query.css("#dropdown-custom button[aria-haspopup=menu]")
+  @dropdown_menu Query.css("#dropdown-custom [role=menu]")
+
+  feature "dropdown_trigger as custom component receives accessibility attributes", %{
+    session: session
+  } do
+    session
+    |> visit_fixture("/fixtures/dropdown-custom-components", "#dropdown-custom")
+    |> assert_has(@dropdown_container)
+    |> assert_has(@dropdown_trigger)
+    |> assert_has(Query.css("#dropdown-custom button[aria-haspopup='menu']"))
+    |> assert_has(Query.css("#dropdown-custom button[aria-expanded='false']"))
+    |> assert_has(Query.css("#dropdown-custom button[data-custom-attr='test-value']"))
+  end
+
+  feature "dropdown_item as custom component receives accessibility attributes", %{
+    session: session
+  } do
+    session
+    |> visit_fixture("/fixtures/dropdown-custom-components", "#dropdown-custom")
+    |> click(@dropdown_trigger)
+    |> assert_has(@dropdown_menu |> Query.visible(true))
+    |> assert_has(Query.css("#dropdown-custom a[role=menuitem]") |> Query.count(2))
+    |> assert_has(Query.css("#dropdown-custom a[role=menuitem][tabindex='-1']") |> Query.count(2))
+    |> assert_has(Query.css("#dropdown-custom a[role=menuitem]:nth-child(2)", text: "Link Item"))
+    |> assert_has(
+      Query.css("#dropdown-custom a[role=menuitem][data-phx-link='redirect']", text: "Link Item")
+    )
+  end
+
+  feature "dropdown_item disabled attribute is passed through to custom component", %{
+    session: session
+  } do
+    session
+    |> visit_fixture("/fixtures/dropdown-custom-components", "#dropdown-custom")
+    |> click(@dropdown_trigger)
+    |> assert_has(@dropdown_menu |> Query.visible(true))
+    |> assert_has(Query.css("#dropdown-custom a[role=menuitem][aria-disabled='true']"))
+    |> assert_has(
+      Query.css("#dropdown-custom a[role=menuitem][aria-disabled='true'][data-disabled='true']")
+    )
+    |> assert_has(
+      Query.css("#dropdown-custom [role=menuitem]:nth-child(3)", text: "Disabled Link")
+    )
+  end
+
+  feature "keyboard navigation works with custom component items", %{session: session} do
+    session
+    |> visit_fixture("/fixtures/dropdown-custom-components", "#dropdown-custom")
+    |> click(@dropdown_trigger)
+    |> assert_has(@dropdown_menu |> Query.visible(true))
+    # Navigate down to first item (regular div)
+    |> send_keys([:down_arrow])
+    |> assert_has(Query.css("#dropdown-custom [role=menuitem]:nth-child(1)[data-focus]"))
+    # Navigate down to second item (link)
+    |> send_keys([:down_arrow])
+    |> assert_has(Query.css("#dropdown-custom a[role=menuitem]:nth-child(2)[data-focus]"))
+    |> assert_missing(Query.css("#dropdown-custom [role=menuitem]:nth-child(1)[data-focus]"))
+  end
+end


### PR DESCRIPTION
- Add attr :rest, :global to dropdown_trigger and dropdown_item
- Add attr :navigate and attr :href to dropdown_item for custom link components
- Properly merge and pass through :rest attributes to custom components
- Add comprehensive documentation about custom component requirements
- Create test fixture and tests for custom component rendering
- Verify change tracking works correctly with Map.merge operations